### PR TITLE
Fix warning due to missing error handling on missing running status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ ipch
 *.user
 .vs
 mididumps
+build/
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,12 @@ target_sources(${PROJECT_NAME} PUBLIC
     BASE_DIRS
       MidiFile
 )
+
+add_executable(${PROJECT_NAME}Test EXCLUDE_FROM_ALL
+  main.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}Test
+  PRIVATE
+    ${PROJECT_NAME}
+)

--- a/MidiFile/MidiEvents/MetaEvents/MidiTimeSignatureMetaEvent.h
+++ b/MidiFile/MidiEvents/MetaEvents/MidiTimeSignatureMetaEvent.h
@@ -8,16 +8,16 @@ class MidiTimeSignatureMetaEvent : public MidiMetaEvent
 {
 	/*
 		Time Signature
-		This meta event is used to set a sequences time signature. 
+		This meta event is used to set a sequences time signature.
 		The time signature defined with 4 bytes, a numerator, a denominator, a metronome pulse and number of 32nd notes per MIDI quarter-note.
-		The numerator is specified as a literal value, but the denominator is specified as (get ready) 
-		the value to which the power of 2 must be raised to equal the number of subdivisions per whole note. 
-		For example, a value of 0 means a whole note because 2 to the power of 0 is 1 (whole note), 
-		a value of 1 means a half-note because 2 to the power of 1 is 2 (half-note), and so on. 
-		The metronome pulse specifies how often the metronome should click in terms of the number of clock signals per click, 
-		which come at a rate of 24 per quarter-note. For example, a value of 24 would mean to click once every quarter-note (beat) and 
-		a value of 48 would mean to click once every half-note (2 beats). And finally, the fourth uint8_t specifies the number of 32nd notes per 24 MIDI clock signals. 
-		This value is usually 8 because there are usually 8 32nd notes in a quarter-note. At least one Time Signature Event should appear in the first track chunk 
+		The numerator is specified as a literal value, but the denominator is specified as (get ready)
+		the value to which the power of 2 must be raised to equal the number of subdivisions per whole note.
+		For example, a value of 0 means a whole note because 2 to the power of 0 is 1 (whole note),
+		a value of 1 means a half-note because 2 to the power of 1 is 2 (half-note), and so on.
+		The metronome pulse specifies how often the metronome should click in terms of the number of clock signals per click,
+		which come at a rate of 24 per quarter-note. For example, a value of 24 would mean to click once every quarter-note (beat) and
+		a value of 48 would mean to click once every half-note (2 beats). And finally, the fourth uint8_t specifies the number of 32nd notes per 24 MIDI clock signals.
+		This value is usually 8 because there are usually 8 32nd notes in a quarter-note. At least one Time Signature Event should appear in the first track chunk
 		(or all track chunks in a Type 2 file) before any non-zero delta time events. If one is not specified 4/4, 24, 8 should be assumed.
 	*/
 public:
@@ -29,7 +29,6 @@ public:
 		m_denominator = data[1];
 		m_metronome = data[2];
 		m_32nds = data[3];
-		uint32_t bla = pow(2, m_denominator);
 	}
 
 	virtual std::string to_string()

--- a/MidiFile/MidiFile.h
+++ b/MidiFile/MidiFile.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <filesystem>
 #include <fstream>
+#include <cstring>
 
 class MidiFile
 {
@@ -17,7 +18,7 @@ public:
 	{
 		unsigned int file_size;
 		uint8_t* data = read_file(file_name, file_size);
-		
+
 		if (data && file_size > MidiHeaderChunk::HEADER_PARSE_SIZE)
 		{
 			int header_location = m_header_chunk.header_location(data);
@@ -211,21 +212,21 @@ private:
 				return false;
 
 			file_position += MidiTrackChunk::HEADER_SIZE;
-			
+
 			chunk->chunk_size = Midi::parse_uint32(file_position);
 			file_position += sizeof(uint32_t);
-			
+
 			chunk->data = new uint8_t[chunk->chunk_size];
 			memcpy(chunk->data, file_position, chunk->chunk_size);
 			file_position += chunk->chunk_size;
-			
+
 			++current_track;
 			track_chunks.push_back(chunk);
 			if (!chunk->parse())
 				return false;
 		}
 		while(current_track < num_tracks + 1u);
-	
+
 		//int file_size = file_position - data; // TODO verify
 		return true;
 	}

--- a/MidiFile/MidiHeaderChunk.h
+++ b/MidiFile/MidiHeaderChunk.h
@@ -2,6 +2,7 @@
 
 #include "Midi.h"
 #include "MidiFile.h"
+#include <cstring>
 
 static const char* MIDI_HEADER_DATA = "MThd";
 
@@ -30,7 +31,7 @@ public:
 	int32_t header_location(uint8_t* data)
 	{
 		std::string header = std::string((const char*) data, HEADER_PARSE_SIZE);
-		
+
 		size_t header_location = header.find(MIDI_HEADER_DATA);
 		if (header_location == std::string::npos)
 		{

--- a/main.cpp
+++ b/main.cpp
@@ -1,15 +1,23 @@
 // MidiFile.cpp : Defines the entry point for the console application.
 //
 
-#include "stdafx.h"
+#include <iostream>
+
 #include "MidiFile/MidiFile.h"
 
 int main(int argc, char* argv[])
 {
-	//MidiFile m("d:/dancing queen.MID";)
-	//MidiFile m("d:/n.mid");
-	//MidiFile m("d:/level07.mid");
-	MidiFile m("d:/black.mid");
-	//MidiFile m("d:/maps.mid");
-	m.dump_tracks("d:/mididumps");
+    if (argc < 3) {
+        std::cout << "Usage: " << argv[0] << " <OUTPUTDIR> <FILENAME>" << std::endl;
+        std::exit(-1);
+    }
+
+    const auto outputDir = argv[1];
+    const auto midiFile = argv[2];
+
+    std::cout << "Parsing " << midiFile << std::endl;
+    MidiFile m(midiFile);
+
+    std::cout << "Dumping to: " << outputDir << std::endl;
+    m.dump_tracks(outputDir);
 }


### PR DESCRIPTION
A specific error was ignored: having an event that depends on running status to be in effect, but that was cancelled. One file was failing: `/Testmidi/QFG4GM1S.MID`