### PR TITLE
Fix parsing issues with META and SYSEX events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 4.0)
 
 project(MidiFile CXX)
 
+if(PROJECT_IS_TOP_LEVEL)
+  add_definitions(-g2 -Wall -Wextra -Werror)
+endif()
+
 add_library(${PROJECT_NAME} INTERFACE)
 
 target_sources(${PROJECT_NAME} PUBLIC

--- a/MidiFile/MidiEvents/ChannelEvents/MidiProgramChangeEvent.h
+++ b/MidiFile/MidiEvents/ChannelEvents/MidiProgramChangeEvent.h
@@ -24,6 +24,7 @@ public:
 
 	void set_program_number(uint8_t program_number)
 	{
+        m_program_number = program_number;
 	}
 
 	virtual std::string to_string()

--- a/MidiFile/MidiEvents/MetaEvents/MidiCopyrightNoticeMetaEvent.h
+++ b/MidiFile/MidiEvents/MetaEvents/MidiCopyrightNoticeMetaEvent.h
@@ -16,7 +16,7 @@ public:
 		{
 			// error
 		}
-		m_copyright_notice = Midi::parse_string(data + 1, m_message_length);
+		m_copyright_notice = parse_string();
 	}
 
 	virtual std::string to_string()

--- a/MidiFile/MidiEvents/MetaEvents/MidiCuePointMetaEvent.h
+++ b/MidiFile/MidiEvents/MetaEvents/MidiCuePointMetaEvent.h
@@ -10,7 +10,7 @@ public:
 	MidiCuePointMetaEvent(TICKS delta_time, uint8_t* data, TICKS song_time)
 	: MidiMetaEvent(delta_time, data, song_time, MidiMetaEvent::CUE_POINT)
 	{
-		m_cue_point = Midi::parse_string(data + 1, m_message_length);
+		m_cue_point = parse_string();
 	}
 
 	virtual std::string to_string()

--- a/MidiFile/MidiEvents/MetaEvents/MidiEndOfTrackMetaEvent.h
+++ b/MidiFile/MidiEvents/MetaEvents/MidiEndOfTrackMetaEvent.h
@@ -11,7 +11,6 @@ public:
 	: MidiMetaEvent(delta_time, data, song_time, MidiMetaEvent::END_OF_TRACK)
 	{
 		m_channel = *data;
-		m_message_length = 0;
 	}
 
 	virtual std::string to_string()

--- a/MidiFile/MidiEvents/MetaEvents/MidiInstrumentNameMetaEvent.h
+++ b/MidiFile/MidiEvents/MetaEvents/MidiInstrumentNameMetaEvent.h
@@ -10,7 +10,7 @@ public:
 	MidiInstrumentNameMetaEvent(TICKS delta_time, uint8_t* data, TICKS song_time)
 	: MidiMetaEvent(delta_time, data, song_time, MidiMetaEvent::INSTRUMENT_NAME)
 	{
-		m_instrument_name = Midi::parse_string(data + 1, m_message_length);
+		m_instrument_name = parse_string();
 	}
 
 	virtual std::string to_string()

--- a/MidiFile/MidiEvents/MetaEvents/MidiLyricsMetaEvent.h
+++ b/MidiFile/MidiEvents/MetaEvents/MidiLyricsMetaEvent.h
@@ -10,7 +10,7 @@ public:
 	MidiLyricsMetaEvent(TICKS delta_time, uint8_t* data, TICKS song_time)
 	: MidiMetaEvent(delta_time, data, song_time, MidiMetaEvent::LYRICS)
 	{
-		m_lyrics = Midi::parse_string(data + 1, m_message_length);
+		m_lyrics = parse_string();
 	}
 
 	virtual std::string to_string()

--- a/MidiFile/MidiEvents/MetaEvents/MidiMarkerMetaEvent.h
+++ b/MidiFile/MidiEvents/MetaEvents/MidiMarkerMetaEvent.h
@@ -10,7 +10,7 @@ public:
 	MidiMarkerMetaEvent(TICKS delta_time, uint8_t* data, TICKS song_time)
 	: MidiMetaEvent(delta_time, data, song_time, MidiMetaEvent::MARKER)
 	{
-		m_marker = Midi::parse_string(data + 1, m_message_length);
+		m_marker = parse_string();
 	}
 
 	virtual std::string to_string()

--- a/MidiFile/MidiEvents/MetaEvents/MidiMetaEvent.h
+++ b/MidiFile/MidiEvents/MetaEvents/MidiMetaEvent.h
@@ -33,9 +33,8 @@ public:
 	, m_data(data)
 	, m_meta_event_type(meta_event_type)
 	{
-		uint32_t bytes_read;
-		m_message_length = Midi::parse_var_length(data, bytes_read);
-		m_data += bytes_read;
+		m_payload_length = Midi::parse_var_length(data, m_payload_offset);
+        m_message_length = m_payload_length + m_payload_offset;
 	}
 
 	META_EVENT_TYPE meta_event_type() const
@@ -45,6 +44,11 @@ public:
 
 	virtual std::string to_string() = 0;
 protected:
+    std::string parse_string() {
+		return Midi::parse_string(m_data + m_payload_offset, m_payload_length);
+    }
+    uint32_t m_payload_offset;
+    uint32_t m_payload_length;
 	uint8_t* m_data;
 
 private:

--- a/MidiFile/MidiEvents/MetaEvents/MidiSequenceTrackNameMetaEvent.h
+++ b/MidiFile/MidiEvents/MetaEvents/MidiSequenceTrackNameMetaEvent.h
@@ -10,7 +10,7 @@ public:
 	MidiSequenceTrackNameMetaEvent(TICKS delta_time, uint8_t* data, TICKS song_time)
 		: MidiMetaEvent(delta_time, data, song_time, MidiMetaEvent::SEQUENCE_TRACK_NAME)
 	{
-		m_track_name = Midi::parse_string(data + 1, m_message_length);
+		m_track_name = parse_string();
 	}
 
 	virtual std::string to_string()

--- a/MidiFile/MidiEvents/MetaEvents/MidiTextMetaEvent.h
+++ b/MidiFile/MidiEvents/MetaEvents/MidiTextMetaEvent.h
@@ -10,7 +10,7 @@ public:
 	MidiTextMetaEvent(TICKS delta_time, uint8_t* data, TICKS song_time)
 	: MidiMetaEvent(delta_time, data, song_time, MidiMetaEvent::TEXT)
 	{
-		m_text = Midi::parse_string(data + 1, m_message_length);
+        m_text = parse_string();
 	}
 
 	virtual std::string to_string()

--- a/MidiFile/MidiEvents/MidiEvent.h
+++ b/MidiFile/MidiEvents/MidiEvent.h
@@ -14,7 +14,8 @@ public:
 		PROGRAM_CHANGE		= 0xC0,
 		CHANNEL_AFTERTOUCH  = 0xD0,
 		PITCH_BEND			= 0xE0,
-		SYSEX				= 0xF0,
+        SYSEX               = 0xF0,
+        SYSEX_CNT_END       = 0xF7,
 		META				= 0xFF
 	};
 
@@ -73,7 +74,7 @@ public:
 
 protected:
 	uint32_t m_message_length;
-	
+
 	void copy_message(const uint8_t* data, uint32_t length)
 	{
 		m_message = new uint8_t[length];

--- a/MidiFile/MidiEvents/SysexEvents/MidiSysexEvent.h
+++ b/MidiFile/MidiEvents/SysexEvents/MidiSysexEvent.h
@@ -110,8 +110,9 @@ inline std::string get_manufacturer_string(EMidiManufacturer manufacturer)
 class MidiSysexEvent : public MidiEvent
 {
 public:
-	MidiSysexEvent(TICKS delta_time, uint8_t* data, uint32_t event_length, TICKS song_time)
+	MidiSysexEvent(TICKS delta_time, uint8_t* data, uint32_t event_length, TICKS song_time, bool continuation)
 	: MidiEvent(MidiEvent::SYSEX, delta_time, song_time)
+        , m_continuation(continuation)
 	{
 		m_message_length = event_length;
 		copy_message(data, event_length);
@@ -140,9 +141,13 @@ public:
 	{
         std::stringstream ss;
         ss << song_time() << "(" << real_time() << ")" << "SYSEX EVENT Manufacturer = " << get_manufacturer_string(m_manufacturer);
+        if (m_continuation) {
+            ss << " Continuation";
+        }
         return ss.str();
 	}
 
 private:
     EMidiManufacturer m_manufacturer;
+    bool m_continuation;
 };

--- a/MidiFile/MidiFile.h
+++ b/MidiFile/MidiFile.h
@@ -33,6 +33,7 @@ public:
 
 	bool save(const std::string& file_name)
 	{
+        (void)file_name;
 		return true;
 	}
 

--- a/MidiFile/MidiTrackChunk.h
+++ b/MidiFile/MidiTrackChunk.h
@@ -73,7 +73,7 @@ public:
 
 	bool parse()
 	{
-        constexpr uint8_t NO_STATUS = 0;
+        constexpr uint8_t NO_STATUS = 0u;
 
 		uint8_t* file_pos = data;
 		uint8_t last_status_byte = NO_STATUS;

--- a/MidiFile/MidiTrackChunk.h
+++ b/MidiFile/MidiTrackChunk.h
@@ -187,7 +187,7 @@ private:
 
 	uint32_t parse_meta_event(TICKS delta_time, uint8_t* file_pos, TICKS song_time)
 	{
-		uint32_t bytes_read = 1;
+		uint32_t bytes_read = 0;
 		uint8_t meta_event_type = *file_pos;
 		bytes_read++; file_pos++;
 		MidiMetaEvent* e = nullptr;


### PR DESCRIPTION
This fixes 2 parsing issues:
1. META events use varlen for size. The file pointer was not moved correctly when the varlen used more than 1 byte.
2. SYSEX events can be split. The continuation of the SYSEX event is now processed to ensure further processing of the file is correct.